### PR TITLE
Lab2 C: persistence

### DIFF
--- a/src/raft/README.md
+++ b/src/raft/README.md
@@ -64,3 +64,7 @@ C: [{nil},{101, 1},{103, 2}, {104, 3}]
 - `persist()` before responding to RPCs: `Start()`, `AppendEntries()`, `RequestVote()` (Figure 2)
 - if RPC fails, simply let it retry at netxt heartbeat, no need to write retry logic.
 - For debug, print out the logs, request reply to fix the boundary condition
+- The lock strategy here is:
+    - lock -> read state -> prepare request arguments -> unlock 
+    - send request
+    - lock -> read result -> update state -> unlock

--- a/src/raft/README.md
+++ b/src/raft/README.md
@@ -61,4 +61,6 @@ C: [{nil},{101, 1},{103, 2}, {104, 3}]
 - Uncommited logs `{102, 1},{103, 1},{104, 1}` in A are removed.
 
 ## Lab 2C Notes
-- Update to stable storage before responding to RPCs: `Start()`, `AppendEntries()`, `RequestVote()` (Figure 2)
+- `persist()` before responding to RPCs: `Start()`, `AppendEntries()`, `RequestVote()` (Figure 2)
+- if RPC fails, simply let it retry at netxt heartbeat, no need to write retry logic.
+- For debug, print out the logs, request reply to fix the boundary condition

--- a/src/raft/README.md
+++ b/src/raft/README.md
@@ -59,3 +59,6 @@ B: [{nil},{101, 1},{103, 2}]
 C: [{nil},{101, 1},{103, 2}, {104, 3}]
 ```
 - Uncommited logs `{102, 1},{103, 1},{104, 1}` in A are removed.
+
+## Lab 2C Notes
+- Update to stable storage before responding to RPCs: `Start()`, `AppendEntries()`, `RequestVote()` (Figure 2)

--- a/src/raft/config.go
+++ b/src/raft/config.go
@@ -303,7 +303,7 @@ func (cfg *config) cleanup() {
 
 // attach server i to the net.
 func (cfg *config) connect(i int) {
-	// fmt.Printf("connect(%d)\n", i)
+	fmt.Printf("connect(%d)\n", i)
 
 	cfg.connected[i] = true
 
@@ -326,7 +326,7 @@ func (cfg *config) connect(i int) {
 
 // detach server i from the net.
 func (cfg *config) disconnect(i int) {
-	// fmt.Printf("disconnect(%d)\n", i)
+	fmt.Printf("disconnect(%d)\n", i)
 
 	cfg.connected[i] = false
 

--- a/src/raft/raft.go
+++ b/src/raft/raft.go
@@ -19,12 +19,13 @@ package raft
 
 import (
 	//	"bytes"
+	"bytes"
 	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
 
-	//	"6.824/labgob"
+	"6.824/labgob"
 	"6.824/lablog"
 	"6.824/labrpc"
 	"6.824/labutil"
@@ -98,15 +99,17 @@ func (rf *Raft) GetState() (int, bool) {
 // save Raft's persistent state to stable storage,
 // where it can later be retrieved after a crash and restart.
 // see paper's Figure 2 for a description of what should be persistent.
+// Persistent state on all servers: currentTerm, votedFor, log[]
 func (rf *Raft) persist() {
 	// Your code here (2C).
 	// Example:
-	// w := new(bytes.Buffer)
-	// e := labgob.NewEncoder(w)
-	// e.Encode(rf.xxx)
-	// e.Encode(rf.yyy)
-	// data := w.Bytes()
-	// rf.persister.SaveRaftState(data)
+	w := new(bytes.Buffer)
+	e := labgob.NewEncoder(w)
+	e.Encode(rf.getCurrentTerm())
+	e.Encode(rf.getVotedFor())
+	e.Encode(rf.Log)
+	data := w.Bytes()
+	rf.persister.SaveRaftState(data)
 }
 
 // restore previously persisted state.
@@ -116,17 +119,21 @@ func (rf *Raft) readPersist(data []byte) {
 	}
 	// Your code here (2C).
 	// Example:
-	// r := bytes.NewBuffer(data)
-	// d := labgob.NewDecoder(r)
-	// var xxx
-	// var yyy
-	// if d.Decode(&xxx) != nil ||
-	//    d.Decode(&yyy) != nil {
-	//   error...
-	// } else {
-	//   rf.xxx = xxx
-	//   rf.yyy = yyy
-	// }
+	r := bytes.NewBuffer(data)
+	d := labgob.NewDecoder(r)
+	var currTerm int32
+	var votedFor int32
+	var logs []LogEntry
+
+	if d.Decode(&currTerm) != nil ||
+		d.Decode(&votedFor) != nil ||
+		d.Decode(&logs) != nil {
+		lablog.Debug(rf.me, lablog.Error, "readPersist failed")
+	} else {
+		rf.setCurrentTerm(currTerm)
+		rf.setVotedFor(votedFor)
+		rf.Log = logs
+	}
 }
 
 // A service wants to switch to snapshot.  Only do so if Raft hasn't
@@ -198,6 +205,7 @@ func (rf *Raft) RequestVote(args *RequestVoteArgs, reply *RequestVoteReply) {
 		// persist votedFor to avoid voting twice within one term
 		rf.setVotedFor(args.CandidateId)
 	}
+	rf.persist()
 	rf.mu.Unlock()
 	// IMPORTANT: to reset election timeout
 	// otherwise, the follower will frequently timeout and start a new election
@@ -358,6 +366,7 @@ func (rf *Raft) Start(command interface{}) (int, int, bool) {
 	}
 	appendedIndex := rf.appendLog(le)
 	lablog.Debug(rf.me, lablog.Start, "start agreement on command %+v at index %d", command, appendedIndex)
+	rf.persist()
 	return appendedIndex, int(term), isLeader
 }
 
@@ -692,11 +701,13 @@ func (rf *Raft) AppendEntries(args *AppendEntriesArgs, reply *AppendEntriesReply
 	if args.PrevLogIndex > len(rf.Log)-1 {
 		lablog.Debug(rf.me, lablog.Append, "not success 1 prevLogIndex=%d, but log length=%d", args.PrevLogIndex, len(rf.Log))
 		reply.Success = false
+		rf.persist()
 		return
 	} else if args.PrevLogIndex >= 0 && (len(rf.Log)-1 >= args.PrevLogIndex) && rf.Log[args.PrevLogIndex].Term != args.PrevLogTerm {
 		lablog.Debug(rf.me, lablog.Append, "not success 2 prevLogIndex=%d, prevLogTerm=%d, but log[%d].Term=%d", args.PrevLogIndex, args.PrevLogTerm, args.PrevLogIndex, rf.Log[args.PrevLogIndex].Term)
 		// If an existing entry conflicts with a new one (same index but different terms)
 		reply.Success = false
+		rf.persist()
 		return
 	} else {
 		lablog.Debug(rf.me, lablog.Append, "append logs %+v", args.Logs)
@@ -709,6 +720,7 @@ func (rf *Raft) AppendEntries(args *AppendEntriesArgs, reply *AppendEntriesReply
 		rf.setCommitIndex(labutil.Min(args.LeaderCommit, rf.Log[len(rf.Log)-1].Index))
 		rf.applyMsgs(rf.applyCh)
 	}
+	rf.persist()
 }
 
 // the service or tester wants to create a Raft server. the ports

--- a/src/test.sh
+++ b/src/test.sh
@@ -11,3 +11,7 @@ for i in $(seq 1 $TIMES); do
   VERBOSE=1 go test ./raft/... -race -run 2B -count=1
 done
 
+for i in $(seq 1 $TIMES); do
+  echo "Running test 2C-$i"
+  VERBOSE=1 go test ./raft/... -race -run "(TestPersist12C|TestPersist22C|TestPersist32C|TestFigure82C)" -count=1 >> log.txt
+done

--- a/src/test.sh
+++ b/src/test.sh
@@ -13,5 +13,5 @@ done
 
 for i in $(seq 1 $TIMES); do
   echo "Running test 2C-$i"
-  VERBOSE=1 go test ./raft/... -race -run "(TestPersist12C|TestPersist22C|TestPersist32C|TestFigure82C)" -count=1 >> log.txt
+  VERBOSE=1 go test ./raft/... -race -run 2C -count=1
 done


### PR DESCRIPTION
## Part 2C: persistence ([hard](http://nil.csail.mit.edu/6.824/2021/labs/guidance.html))

If a Raft-based server reboots it should resume service where it left off. This requires that Raft keep persistent state that survives a reboot. The paper's Figure 2 mentions which state should be persistent.

A real implementation would write Raft's persistent state to disk each time it changed, and would read the state from disk when restarting after a reboot. Your implementation won't use the disk; instead, it will save and restore persistent state from a Persister object (see persister.go). Whoever calls Raft.Make() supplies a Persister that initially holds Raft's most recently persisted state (if any). Raft should initialize its state from that Persister, and should use it to save its persistent state each time the state changes. Use the Persister's ReadRaftState() and SaveRaftState() methods.

## Changes
- persist and readPersist
- timing to persist
-  refactor: simply retry in next heartbeat interval 
- retry optimization with `XTerm` and `XIndex`

## Test Result
```
=== RUN   TestPersist12C
Test (2C): basic persistence ...
  ... Passed --   5.8  3   88   21544    6
--- PASS: TestPersist12C (5.81s)
=== RUN   TestPersist22C
Test (2C): more persistence ...
  ... Passed --  27.5  5 1345  288715   16
--- PASS: TestPersist22C (27.50s)
=== RUN   TestPersist32C
Test (2C): partitioned leader and one follower crash, leader restarts ...
  ... Passed --   2.9  3   34    8667    4
--- PASS: TestPersist32C (2.88s)
=== RUN   TestFigure82C
Test (2C): Figure 8 ...
  ... Passed --  34.1  5  292   54381    8
--- PASS: TestFigure82C (34.14s)
=== RUN   TestUnreliableAgree2C
Test (2C): unreliable agreement ...
  ... Passed --   6.0  5  216   77832  246
--- PASS: TestUnreliableAgree2C (5.99s)
=== RUN   TestFigure8Unreliable2C
Test (2C): Figure 8 (unreliable) ...
  ... Passed --  37.4  5 3040 13010002  422
--- PASS: TestFigure8Unreliable2C (37.41s)
=== RUN   TestReliableChurn2C
Test (2C): churn ...
  ... Passed --  16.3  5  628  710396  364
--- PASS: TestReliableChurn2C (16.26s)
=== RUN   TestUnreliableChurn2C
Test (2C): unreliable churn ...
  ... Passed --  16.3  5  604  423999  250
--- PASS: TestUnreliableChurn2C (16.30s)
PASS
ok  	6.824/raft	147.442s

```