### PR TITLE
Part 2D: log compaction

### DIFF
--- a/src/lablog/lablog.go
+++ b/src/lablog/lablog.go
@@ -26,16 +26,17 @@ func getVerbosity() int {
 type LogTopic string
 
 const (
-	Heart  LogTopic = "HART"
-	Info   LogTopic = "INFO"
-	Config LogTopic = "CONF"
-	Vote   LogTopic = "VOTE"
-	Timer  LogTopic = "TIMR"
-	Leader LogTopic = "LEAD"
-	Append LogTopic = "APND"
-	Error  LogTopic = "ERRO"
-	Start  LogTopic = "STRT"
-	Commit LogTopic = "COMT"
+	Heart    LogTopic = "HART"
+	Info     LogTopic = "INFO"
+	Config   LogTopic = "CONF"
+	Vote     LogTopic = "VOTE"
+	Timer    LogTopic = "TIMR"
+	Leader   LogTopic = "LEAD"
+	Append   LogTopic = "APND"
+	Error    LogTopic = "ERRO"
+	Start    LogTopic = "STRT"
+	Commit   LogTopic = "COMT"
+	Snapshot LogTopic = "SNAP"
 )
 
 var debugStart time.Time

--- a/src/raft/README.md
+++ b/src/raft/README.md
@@ -68,3 +68,17 @@ C: [{nil},{101, 1},{103, 2}, {104, 3}]
     - lock -> read state -> prepare request arguments -> unlock 
     - send request
     - lock -> read result -> update state -> unlock
+
+## Lab 2D Notes
+### Flows
+#### Snapshot
+1. Application calls `Snapshot` to raft node.
+    - ref: `applierSnap` of [config.go](./config.go)
+2. Raft `Snapshot`
+
+#### Sync Snapshot
+3. Leader send `InstallSnapshot` RPC to follower
+4. Follower received `InstallSnapshot` RPC from leader
+    - follower checks the snapshot freshness
+    - if ok, send `ApplyMsg` to application through channel.
+5. Application received `ApplyMsg` and calls `CondInstallSnapshot` to install snapshot.

--- a/src/raft/raft.go
+++ b/src/raft/raft.go
@@ -138,6 +138,12 @@ func (rf *Raft) readPersist(data []byte) {
 		rf.setVotedFor(votedFor)
 		rf.logs = logs
 	}
+	// what happens on crash+restart?
+	// service reads snapshot from disk Raft reads persisted log from disk
+	// service tells Raft to set lastApplied to last included index
+	// to avoid re-applying already-applied log entries
+	// ref: http://nil.csail.mit.edu/6.824/2021/notes/l-raft2.txt
+	rf.lastApplied = rf.baseIndex()
 }
 
 // A service wants to switch to snapshot.  Only do so if Raft hasn't
@@ -977,7 +983,6 @@ func Make(peers []*labrpc.ClientEnd, me int,
 
 	// initialize from state persisted before a crash
 	rf.readPersist(persister.ReadRaftState())
-	rf.persister.ReadSnapshot()
 
 	// start ticker goroutine to start elections
 	go rf.ticker()

--- a/src/raft/raft_state.go
+++ b/src/raft/raft_state.go
@@ -168,6 +168,10 @@ func (rf *raftState) setNextIndex(nextIdx []int) {
 	rf.nextIndex = nextIdx
 }
 
+func (rf *raftState) getNodeNextIndex(nodeID int) int {
+	return rf.nextIndex[nodeID]
+}
+
 func (rf *raftState) setNodeNextIndex(nodeID, nextIdx int) error {
 	if len(rf.nextIndex) == 0 {
 		return errors.New("empty nextIndex")

--- a/src/raft/raft_state.go
+++ b/src/raft/raft_state.go
@@ -62,7 +62,10 @@ func newRaftState() raftState {
 		currentTerm: 0,
 		dead:        0,
 		votedFor:    voteForNull,
-		// keep a dummy entry
+		// The Leader Completeness Property guarantees that a leader has all committed entries,
+		// but at the start of its term, it may not know which those are.
+		// To find out, it needs to commit an entry from its term.
+		// Raft handles this by having each leader commit a blank no-op entry into the log at the start of its term. ($9)
 		// after 2D it serves as logical index offset.
 		logs: []LogEntry{
 			{Term: 0, Index: 0, Command: nil},

--- a/src/test.sh
+++ b/src/test.sh
@@ -15,3 +15,8 @@ for i in $(seq 1 $TIMES); do
   echo "Running test 2C-$i"
   VERBOSE=1 go test ./raft/... -race -run 2C -count=1
 done
+
+for i in $(seq 1 $TIMES); do
+  echo "Running test 2C-$i"
+  VERBOSE=1 go test ./raft/... -race -run "(TestSnapshotBasic2D)" -count=1
+done

--- a/src/test.sh
+++ b/src/test.sh
@@ -17,6 +17,6 @@ for i in $(seq 1 $TIMES); do
 done
 
 for i in $(seq 1 $TIMES); do
-  echo "Running test 2C-$i"
-  VERBOSE=1 go test ./raft/... -race -run "(TestSnapshotBasic2D)" -count=1
+  echo "Running test 2D-$i"
+  VERBOSE=1 go test ./raft/... -race -run "(TestSnapshotBasic2D|TestSnapshotInstall2D)" -count=1
 done

--- a/src/test.sh
+++ b/src/test.sh
@@ -18,5 +18,5 @@ done
 
 for i in $(seq 1 $TIMES); do
   echo "Running test 2D-$i"
-  VERBOSE=1 go test ./raft/... -race -run "(TestSnapshotBasic2D|TestSnapshotInstall2D)" -count=1
+  VERBOSE=1 go test ./raft/... -race -run 2D -count=1
 done


### PR DESCRIPTION
## Part 2D: log compaction ([hard](http://nil.csail.mit.edu/6.824/2021/labs/guidance.html))

As things stand now with your code, a rebooting service replays the complete Raft log in order to restore its state. However, it's not practical for a long-running service to remember the complete Raft log forever. Instead, you'll modify Raft to cooperate to save space: from time to time a service will persistently store a "snapshot" of its current state, and Raft will discard log entries that precede the snapshot. When a service falls far behind the leader and must catch up, the service first installs a snapshot and then replays log entries from after the point at which the snapshot was created. Section 7 of the [extended Raft paper](http://nil.csail.mit.edu/6.824/2021/papers/raft-extended.pdf) outlines the scheme; you will have to design the details.

You may find it helpful to refer to the [diagram of Raft interactions](http://nil.csail.mit.edu/6.824/2021/notes/raft_diagram.pdf) to understand how the replicated service and Raft communicate.

To support snapshots, we need an interface between the service and the Raft library. The Raft paper doesn't specify this interface, and several designs are possible. To allow for a simple implementation, we decided on the following interface between service and Raft:

`Snapshot(index int, snapshot []byte)`

`CondInstallSnapshot(lastIncludedTerm int, lastIncludedIndex int, snapshot []byte) bool`

A service calls Snapshot() to communicate the snapshot of its state to Raft. The snapshot includes all info up to and including index. This means the corresponding Raft peer no longer needs the log through (and including) index. Your Raft implementation should trim its log as much as possible. You must revise your Raft code to operate while storing only the tail of the log.

As discussed in the extended Raft paper, Raft leaders must sometimes tell lagging Raft peers to update their state by installing a snapshot. You need to implement InstallSnapshot RPC senders and handlers for installing snapshots when this situation arises. This is in contrast to AppendEntries, which sends log entries that are then applied one by one by the service.


## [Diagram](http://nil.csail.mit.edu/6.824/2021/notes/raft_diagram.pdf)
![image](https://github.com/user-attachments/assets/496b77ff-a290-4838-b439-5074b9079425)


## Test Result
```
$ go test  ./raft/... -v -race -run 2D
=== RUN   TestSnapshotBasic2D
Test (2D): snapshots basic ...
  ... Passed --   7.4  3  134   49860  251
--- PASS: TestSnapshotBasic2D (7.35s)
=== RUN   TestSnapshotInstall2D
Test (2D): install snapshots (disconnect) ...
  ... Passed --  51.0  3 1112  301260  377
--- PASS: TestSnapshotInstall2D (51.03s)
=== RUN   TestSnapshotInstallUnreliable2D
Test (2D): install snapshots (disconnect+unreliable) ...
  ... Passed --  59.1  3 1272  326050  388
--- PASS: TestSnapshotInstallUnreliable2D (59.13s)
=== RUN   TestSnapshotInstallCrash2D
Test (2D): install snapshots (crash) ...
  ... Passed --  40.8  3  694  200675  399
--- PASS: TestSnapshotInstallCrash2D (40.83s)
=== RUN   TestSnapshotInstallUnCrash2D
Test (2D): install snapshots (unreliable+crash) ...
  ... Passed --  47.8  3  774  211406  366
--- PASS: TestSnapshotInstallUnCrash2D (47.79s)
PASS
ok  	6.824/raft	207.402s
```