### PR TITLE
feat: Lab 3A

### DIFF
--- a/src/kvraft/README.md
+++ b/src/kvraft/README.md
@@ -1,4 +1,30 @@
 # Lab KVRaft
+- Lab and requirement: http://nil.csail.mit.edu/6.824/2021/labs/lab-kvraft.html
 - paper: https://web.stanford.edu/~ouster/cgi-bin/papers/OngaroPhD.pdf
 
 ## Part A: Key/value service without snapshots
+### Task 1
+```
+Your first task is to implement a solution that works when there are no dropped messages, and no failed servers.
+
+You'll need to add RPC-sending code to the Clerk Put/Append/Get methods in client.go, and implement PutAppend() and Get() RPC handlers in server.go. These handlers should enter an Op in the Raft log using Start(); you should fill in the Op struct definition in server.go so that it describes a Put/Append/Get operation. Each server should execute Op commands as Raft commits them, i.e. as they appear on the applyCh. An RPC handler should notice when Raft commits its Op, and then reply to the RPC.
+
+You have completed this task when you reliably pass the first test in the test suite: "One client".
+```
+
+### Task 2
+```
+Add code to handle failures, and to cope with duplicate Clerk requests, including situations where the Clerk sends a request to a kvserver leader in one term, times out waiting for a reply, and re-sends the request to a new leader in another term. The request should execute just once. Your code should pass the go test -run 3A -race tests. 
+```
+
+### Architecture
+- 1 kv server - (1 raft node + 1 state machine)
+- 1 client (Clerk) can send to many kv server
+
+### Notes
+- client does not know who is leader before sending request.
+- client needs client ID and request ID for server to de-duplicate requests in unreliable network.
+    - server keep track of last operation of a client.
+- [raft](../raft) code are slightly updated for performance.
+- For each request, server `Start()` then waits for raft applying message through `applyCh`.
+    - multiple command could wait concurrently

--- a/src/kvraft/README.md
+++ b/src/kvraft/README.md
@@ -1,0 +1,4 @@
+# Lab KVRaft
+- paper: https://web.stanford.edu/~ouster/cgi-bin/papers/OngaroPhD.pdf
+
+## Part A: Key/value service without snapshots

--- a/src/kvraft/client.go
+++ b/src/kvraft/client.go
@@ -1,13 +1,19 @@
 package kvraft
 
-import "6.824/labrpc"
-import "crypto/rand"
-import "math/big"
+import (
+	"crypto/rand"
+	"math/big"
 
+	"6.824/labrpc"
+)
 
 type Clerk struct {
 	servers []*labrpc.ClientEnd
 	// You will have to modify this struct.
+
+	ID             int64
+	currentLeader  int // index of the last known leader
+	requestIDCount int64
 }
 
 func nrand() int64 {
@@ -20,11 +26,12 @@ func nrand() int64 {
 func MakeClerk(servers []*labrpc.ClientEnd) *Clerk {
 	ck := new(Clerk)
 	ck.servers = servers
+	ck.ID = nrand()
+	ck.requestIDCount = 0
 	// You'll have to add code here.
 	return ck
 }
 
-//
 // fetch the current value for a key.
 // returns "" if the key does not exist.
 // keeps trying forever in the face of all other errors.
@@ -35,14 +42,25 @@ func MakeClerk(servers []*labrpc.ClientEnd) *Clerk {
 // the types of args and reply (including whether they are pointers)
 // must match the declared types of the RPC handler function's
 // arguments. and reply must be passed as a pointer.
-//
 func (ck *Clerk) Get(key string) string {
-
-	// You will have to modify this function.
-	return ""
+	req := GetArgs{
+		Key: key,
+		ArgsCommon: ArgsCommon{
+			ClientId:  ck.ID,
+			RequestID: ck.requestIDCount,
+		},
+	}
+	for {
+		reply := GetReply{}
+		ok := ck.servers[ck.currentLeader].Call("KVServer.Get", &req, &reply)
+		if ok && !isRetriableError(reply.Err) {
+			ck.requestIDCount++
+			return reply.Value
+		}
+		ck.nextLeader()
+	}
 }
 
-//
 // shared by Put and Append.
 //
 // you can send an RPC with code like this:
@@ -51,9 +69,26 @@ func (ck *Clerk) Get(key string) string {
 // the types of args and reply (including whether they are pointers)
 // must match the declared types of the RPC handler function's
 // arguments. and reply must be passed as a pointer.
-//
 func (ck *Clerk) PutAppend(key string, value string, op string) {
 	// You will have to modify this function.
+	req := PutAppendArgs{
+		Key:   key,
+		Value: value,
+		Op:    op,
+		ArgsCommon: ArgsCommon{
+			ClientId:  ck.ID,
+			RequestID: ck.requestIDCount,
+		},
+	}
+	for {
+		reply := PutAppendReply{}
+		ok := ck.servers[ck.currentLeader].Call("KVServer.PutAppend", &req, &reply)
+		if ok && !isRetriableError(reply.Err) {
+			ck.requestIDCount++
+			return
+		}
+		ck.nextLeader()
+	}
 }
 
 func (ck *Clerk) Put(key string, value string) {
@@ -61,4 +96,9 @@ func (ck *Clerk) Put(key string, value string) {
 }
 func (ck *Clerk) Append(key string, value string) {
 	ck.PutAppend(key, value, "Append")
+}
+
+func (ck *Clerk) nextLeader() int {
+	ck.currentLeader = (ck.currentLeader + 1) % len(ck.servers)
+	return ck.currentLeader
 }

--- a/src/kvraft/client.go
+++ b/src/kvraft/client.go
@@ -46,7 +46,7 @@ func (ck *Clerk) Get(key string) string {
 	req := GetArgs{
 		Key: key,
 		ArgsCommon: ArgsCommon{
-			ClientId:  ck.ID,
+			ClientID:  ck.ID,
 			RequestID: ck.requestIDCount,
 		},
 	}
@@ -76,7 +76,7 @@ func (ck *Clerk) PutAppend(key string, value string, op string) {
 		Value: value,
 		Op:    op,
 		ArgsCommon: ArgsCommon{
-			ClientId:  ck.ID,
+			ClientID:  ck.ID,
 			RequestID: ck.requestIDCount,
 		},
 	}

--- a/src/kvraft/common.go
+++ b/src/kvraft/common.go
@@ -14,7 +14,7 @@ func isRetriableError(err Err) bool {
 }
 
 type ArgsCommon struct {
-	ClientId  int64
+	ClientID  int64
 	RequestID int64
 }
 
@@ -42,4 +42,13 @@ type GetArgs struct {
 type GetReply struct {
 	Err   Err
 	Value string
+}
+
+type ClientOpRecord struct {
+	RequestID int64
+	reply     reply
+}
+type reply struct {
+	value string
+	err   Err
 }

--- a/src/kvraft/common.go
+++ b/src/kvraft/common.go
@@ -1,12 +1,22 @@
 package kvraft
 
 const (
-	OK             = "OK"
-	ErrNoKey       = "ErrNoKey"
-	ErrWrongLeader = "ErrWrongLeader"
+	OK           = "OK"
+	ErrNoKey     = "ErrNoKey"
+	ErrNotLeader = "NOT_LEADER"
+	ErrTimeout   = "TIMEOUT"
 )
 
 type Err string
+
+func isRetriableError(err Err) bool {
+	return (err == ErrNotLeader || err == ErrTimeout)
+}
+
+type ArgsCommon struct {
+	ClientId  int64
+	RequestID int64
+}
 
 // Put or Append
 type PutAppendArgs struct {
@@ -16,6 +26,7 @@ type PutAppendArgs struct {
 	// You'll have to add definitions here.
 	// Field names must start with capital letters,
 	// otherwise RPC will break.
+	ArgsCommon
 }
 
 type PutAppendReply struct {
@@ -25,6 +36,7 @@ type PutAppendReply struct {
 type GetArgs struct {
 	Key string
 	// You'll have to add definitions here.
+	ArgsCommon
 }
 
 type GetReply struct {

--- a/src/kvraft/server.go
+++ b/src/kvraft/server.go
@@ -1,12 +1,18 @@
 package kvraft
 
 import (
-	"6.824/labgob"
-	"6.824/labrpc"
-	"6.824/raft"
 	"log"
 	"sync"
 	"sync/atomic"
+	"time"
+
+	"6.824/labgob"
+	"6.824/labrpc"
+	"6.824/raft"
+)
+
+const (
+	timeout = 3 * time.Second
 )
 
 const Debug = false
@@ -18,15 +24,31 @@ func DPrintf(format string, a ...interface{}) (n int, err error) {
 	return
 }
 
+type OpType uint8
+
+const (
+	OpGet OpType = iota
+	OpPut
+	OpAppend
+)
 
 type Op struct {
 	// Your definitions here.
 	// Field names must start with capital letters,
 	// otherwise RPC will break.
+	Type  OpType
+	Key   string
+	Value string
+}
+
+type stateMachine interface {
+	Get(key string) string
+	Put(key string, value string)
+	Append(key string, value string)
 }
 
 type KVServer struct {
-	mu      sync.Mutex
+	mu      sync.RWMutex
 	me      int
 	rf      *raft.Raft
 	applyCh chan raft.ApplyMsg
@@ -35,18 +57,66 @@ type KVServer struct {
 	maxraftstate int // snapshot if log grows this big
 
 	// Your definitions here.
+	currTerm     uint32
+	resChan      map[int]chan reply
+	stateMachine stateMachine
 }
-
 
 func (kv *KVServer) Get(args *GetArgs, reply *GetReply) {
 	// Your code here.
+	rep := kv.handleOp(Op{
+		Type: OpGet,
+		Key:  args.Key,
+	})
+	reply.Value = rep.value
+	reply.Err = rep.err
 }
 
 func (kv *KVServer) PutAppend(args *PutAppendArgs, reply *PutAppendReply) {
 	// Your code here.
+	op := Op{
+		Key:   args.Key,
+		Value: args.Value,
+	}
+	switch args.Op {
+	case "Put":
+		op.Type = OpPut
+	case "Append":
+		op.Type = OpAppend
+	}
+	rep := kv.handleOp(op)
+	reply.Err = rep.err
 }
 
-//
+type reply struct {
+	value string
+	err   Err
+}
+
+func (kv *KVServer) handleOp(op Op) reply {
+	idx, currTerm, isLeader := kv.rf.Start(op)
+	if !isLeader {
+		return reply{err: ErrNotLeader}
+	}
+	// remove used channels
+	defer func() {
+		kv.mu.Lock()
+		kv.removeResChan(idx)
+		kv.mu.Unlock()
+	}()
+	kv.mu.Lock()
+	kv.setCurrTerm(currTerm)
+	kv.addResChan(idx)
+	resChan := kv.getResChan(idx)
+	kv.mu.Unlock()
+	select {
+	case res := <-resChan:
+		return res
+	case <-time.After(timeout):
+		return reply{err: ErrTimeout}
+	}
+}
+
 // the tester calls Kill() when a KVServer instance won't
 // be needed again. for your convenience, we supply
 // code to set rf.dead (without needing a lock),
@@ -55,7 +125,6 @@ func (kv *KVServer) PutAppend(args *PutAppendArgs, reply *PutAppendReply) {
 // code to Kill(). you're not required to do anything
 // about this, but it may be convenient (for example)
 // to suppress debug output from a Kill()ed instance.
-//
 func (kv *KVServer) Kill() {
 	atomic.StoreInt32(&kv.dead, 1)
 	kv.rf.Kill()
@@ -67,7 +136,6 @@ func (kv *KVServer) killed() bool {
 	return z == 1
 }
 
-//
 // servers[] contains the ports of the set of
 // servers that will cooperate via Raft to
 // form the fault-tolerant key/value service.
@@ -80,7 +148,6 @@ func (kv *KVServer) killed() bool {
 // you don't need to snapshot.
 // StartKVServer() must return quickly, so it should start goroutines
 // for any long-running work.
-//
 func StartKVServer(servers []*labrpc.ClientEnd, me int, persister *raft.Persister, maxraftstate int) *KVServer {
 	// call labgob.Register on structures you want
 	// Go's RPC library to marshall/unmarshall.
@@ -94,8 +161,59 @@ func StartKVServer(servers []*labrpc.ClientEnd, me int, persister *raft.Persiste
 
 	kv.applyCh = make(chan raft.ApplyMsg)
 	kv.rf = raft.Make(servers, me, persister, kv.applyCh)
+	kv.resChan = make(map[int]chan reply)
 
 	// You may need initialization code here.
-
+	kv.stateMachine = NewInMemoryStateMachine()
+	go kv.apply()
 	return kv
+}
+
+// server state
+
+// already known 0 <= term < 2^32
+func (kv *KVServer) setCurrTerm(term int) {
+	atomic.StoreUint32(&kv.currTerm, uint32(term))
+}
+
+func (kv *KVServer) getCurrTerm() int {
+	return int(atomic.LoadUint32(&kv.currTerm))
+}
+
+func (kv *KVServer) addResChan(idx int) {
+	kv.resChan[idx] = make(chan reply, 1)
+}
+
+func (kv *KVServer) getResChan(idx int) chan reply {
+	return kv.resChan[idx]
+}
+
+func (kv *KVServer) removeResChan(idx int) {
+	close(kv.resChan[idx])
+	delete(kv.resChan, idx)
+}
+
+func (kv *KVServer) apply() {
+	for !kv.killed() {
+		msg := <-kv.applyCh
+		rep := reply{}
+		if msg.CommandValid {
+			op := msg.Command.(Op)
+			switch op.Type {
+			case OpGet:
+				value := kv.stateMachine.Get(op.Key)
+				rep = reply{value: value}
+			case OpPut:
+				kv.stateMachine.Put(op.Key, op.Value)
+			case OpAppend:
+				kv.stateMachine.Append(op.Key, op.Value)
+			}
+			kv.mu.RLock()
+			if currTerm, isLeader := kv.rf.GetState(); isLeader && currTerm == kv.getCurrTerm() {
+				kv.getResChan(msg.CommandIndex) <- rep
+			}
+			kv.mu.RUnlock()
+		}
+
+	}
 }

--- a/src/kvraft/state_machine.go
+++ b/src/kvraft/state_machine.go
@@ -1,0 +1,32 @@
+package kvraft
+
+import "sync"
+
+type InMemoryStateMachine struct {
+	mu   sync.RWMutex
+	data map[string]string
+}
+
+func NewInMemoryStateMachine() *InMemoryStateMachine {
+	return &InMemoryStateMachine{
+		data: make(map[string]string),
+	}
+}
+
+func (s *InMemoryStateMachine) Get(key string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.data[key]
+}
+
+func (s *InMemoryStateMachine) Put(key string, value string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[key] = value
+}
+
+func (s *InMemoryStateMachine) Append(key string, value string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[key] += value
+}

--- a/src/raft/raft.go
+++ b/src/raft/raft.go
@@ -54,6 +54,7 @@ type ApplyMsg struct {
 	CommandValid bool
 	Command      interface{}
 	CommandIndex int
+	CommandTerm  int32 // for state machine to check whether the command is outdated
 
 	// For 2D:
 	SnapshotValid bool
@@ -720,6 +721,7 @@ func (rf *Raft) applyMsgs() {
 				CommandValid: true,
 				Command:      entry.Command,
 				CommandIndex: entry.Index,
+				CommandTerm:  entry.Term,
 			}
 			msgs = append(msgs, msg)
 		}

--- a/src/raft/raft.go
+++ b/src/raft/raft.go
@@ -410,11 +410,9 @@ func (rf *Raft) sendRequestVote(server int, args *RequestVoteArgs, reply *Reques
 func (rf *Raft) Start(command interface{}) (int, int, bool) {
 
 	// Your code here (2B).
-	index := -1
-
 	isLeader := rf.getState() == Leader
 	if !isLeader || rf.killed() {
-		return index, 0, isLeader
+		return -1, 0, false
 	}
 	rf.mu.Lock()
 	defer rf.mu.Unlock()

--- a/src/raft/raft.go
+++ b/src/raft/raft.go
@@ -409,14 +409,14 @@ func (rf *Raft) sendRequestVote(server int, args *RequestVoteArgs, reply *Reques
 func (rf *Raft) Start(command interface{}) (int, int, bool) {
 
 	// Your code here (2B).
-	rf.mu.Lock()
-	defer rf.mu.Unlock()
 	index := -1
 
 	isLeader := rf.getState() == Leader
 	if !isLeader || rf.killed() {
 		return index, 0, isLeader
 	}
+	rf.mu.Lock()
+	defer rf.mu.Unlock()
 	term := rf.getCurrentTerm()
 	le := LogEntry{
 		Term:    term,
@@ -425,6 +425,10 @@ func (rf *Raft) Start(command interface{}) (int, int, bool) {
 	appendedIndex := rf.appendLog(le)
 	lablog.Debug(rf.me, lablog.Start, "start agreement on command %+v at index %d", command, appendedIndex)
 	rf.persist()
+
+	// (3A) immediately replicate() for increasing throughput since TestSpeed3A requires 3 ops per heartbeat
+	// before: it was too slow on client side since client blocks next operation until it is committed => 1 operation per heartbeat
+	rf.replicates()
 	return appendedIndex, int(term), isLeader
 }
 
@@ -437,10 +441,8 @@ func (rf *Raft) ticker() {
 		// Your code here to check if a leader election should
 		// be started and to randomize sleeping time using
 		// time.Sleep().
-		rf.mu.Lock()
 		state := rf.getState()
 		lablog.Debug(rf.me, lablog.Timer, "ticker: current state: %s, term: %d", state, rf.getCurrentTerm())
-		rf.mu.Unlock()
 		switch state {
 		case Leader:
 			select {
@@ -481,11 +483,11 @@ func (rf *Raft) ticker() {
 			case <-rf.stepDownCh:
 				// cancel the operation when becomes follower
 			case <-rf.winElectionCh:
-				rf.mu.Lock()
 				if rf.getState() == Candidate {
+					rf.mu.Lock()
 					rf.becomeLeader()
+					rf.mu.Unlock()
 				}
-				rf.mu.Unlock()
 			}
 		}
 	}
@@ -561,12 +563,13 @@ func (rf *Raft) replicates() {
 }
 
 func (rf *Raft) replicaOneNode(nodeID int) {
-	rf.mu.Lock() // lock 1
 	if rf.getState() != Leader {
-		rf.mu.Unlock() // unlock 1
 		return
 	}
-
+	// no need to accumulate goroutine since replicates() might got called many times
+	if !rf.mu.TryLock() {
+		return
+	}
 	idx := rf.getNodeNextIndex(nodeID)
 	currTerm := rf.getCurrentTerm()
 
@@ -591,7 +594,7 @@ func (rf *Raft) replicaOneNode(nodeID int) {
 
 func (rf *Raft) appendEntries(nodeID int, args *AppendEntriesArgs) {
 	rf.mu.Lock() // lock 1
-	if rf.getState() != Leader {
+	if rf.getState() != Leader || rf.getCurrentTerm() != args.Term {
 		rf.mu.Unlock() // unlock 1
 		return
 	}
@@ -710,14 +713,13 @@ func (rf *Raft) applyMsgs() {
 		for rf.getLastApplied() >= rf.commitIndex {
 			rf.applyCond.Wait() // will release lock
 		}
-		msgs := make([]ApplyMsg, 0)
-		newLastApplied := rf.getLastApplied()
-		for newLastApplied < rf.commitIndex {
-			newLastApplied += 1
+		lastApplied, commitIdx := rf.getLastApplied(), rf.commitIndex
+		msgs := make([]ApplyMsg, 0, commitIdx-lastApplied)
+		for _, entry := range rf.logsRange(lastApplied+1, commitIdx) {
 			msg := ApplyMsg{
 				CommandValid: true,
-				Command:      rf.logEntry(newLastApplied).Command,
-				CommandIndex: newLastApplied,
+				Command:      entry.Command,
+				CommandIndex: entry.Index,
 			}
 			msgs = append(msgs, msg)
 		}
@@ -729,8 +731,8 @@ func (rf *Raft) applyMsgs() {
 			rf.applyCh <- msg
 		}
 		rf.mu.Lock()
-		rf.setLastApplied(newLastApplied)
-		lablog.Debug(rf.me, lablog.Info, "applied %d messages, set last applied: %d", len(msgs), newLastApplied)
+		rf.setLastApplied(commitIdx)
+		lablog.Debug(rf.me, lablog.Info, "applied %d messages, set last applied: %d", len(msgs), commitIdx)
 		rf.mu.Unlock()
 	}
 }

--- a/src/raft/raft_state.go
+++ b/src/raft/raft_state.go
@@ -136,7 +136,7 @@ func (rf *raftState) lastLogIndex() int {
 // return the log entry at the given index
 func (rf *raftState) logEntry(index int) *LogEntry {
 	base := rf.baseIndex()
-	if index < base || index > rf.lastLogIndex() {
+	if index < base || index-base >= len(rf.logs) {
 		return nil
 	}
 	return &rf.logs[index-base]
@@ -148,6 +148,18 @@ func (rf *raftState) logsFrom(idx int) []LogEntry {
 		return nil
 	}
 	return rf.logs[idx-base:]
+}
+
+// return the log entries from start to end index (inclusive)
+func (rf *raftState) logsRange(start, end int) []LogEntry {
+	if start > end {
+		return nil
+	}
+	base := rf.baseIndex()
+	if start < base || end < base || start-base >= len(rf.logs) || end-base >= len(rf.logs) {
+		return nil
+	}
+	return rf.logs[start-base : end-base+1]
 }
 
 func (rf *raftState) replaceLogs(logs []LogEntry) {

--- a/src/test.sh
+++ b/src/test.sh
@@ -24,5 +24,5 @@ done
 # kvraft
 for i in $(seq 1 $TIMES); do
   echo "Running test 3A-$i"
-  VERBOSE=1 go test ./kvraft/... -race -run="(TestBasic3A|TestSpeed3A|TestConcurrent3A)" -count=1
+  VERBOSE=1 go test ./kvraft/... -race -run="(TestBasic3A|TestSpeed3A|TestConcurrent3A|TestUnreliable3A|TestUnreliableOneKey3A|TestOnePartition3A|TestManyPartitionsManyClients3A|TestPersistOneClient3A|TestPersistConcurrent3A)" -count=1
 done

--- a/src/test.sh
+++ b/src/test.sh
@@ -20,3 +20,9 @@ for i in $(seq 1 $TIMES); do
   echo "Running test 2D-$i"
   VERBOSE=1 go test ./raft/... -race -run 2D -count=1
 done
+
+# kvraft
+for i in $(seq 1 $TIMES); do
+  echo "Running test 3A-$i"
+  go test ./kvraft/... -race -run="(TestBasic3A)" -count=1
+done

--- a/src/test.sh
+++ b/src/test.sh
@@ -24,5 +24,5 @@ done
 # kvraft
 for i in $(seq 1 $TIMES); do
   echo "Running test 3A-$i"
-  go test ./kvraft/... -race -run="(TestBasic3A)" -count=1
+  VERBOSE=1 go test ./kvraft/... -race -run="(TestBasic3A|TestSpeed3A|TestConcurrent3A)" -count=1
 done

--- a/src/test.sh
+++ b/src/test.sh
@@ -24,5 +24,5 @@ done
 # kvraft
 for i in $(seq 1 $TIMES); do
   echo "Running test 3A-$i"
-  VERBOSE=1 go test ./kvraft/... -race -run="(TestBasic3A|TestSpeed3A|TestConcurrent3A|TestUnreliable3A|TestUnreliableOneKey3A|TestOnePartition3A|TestManyPartitionsManyClients3A|TestPersistOneClient3A|TestPersistConcurrent3A)" -count=1
+  VERBOSE=1 go test ./kvraft/... -race -run=3A -count=1
 done


### PR DESCRIPTION
## Test Result
```
=== RUN   TestBasic3A
Test: one client (3A) ...
  ... Passed --  15.1  5  4769  597
--- PASS: TestBasic3A (15.14s)
=== RUN   TestSpeed3A
Test: ops complete fast enough (3A) ...
  ... Passed --  12.6  3  5539    0
--- PASS: TestSpeed3A (12.60s)
=== RUN   TestConcurrent3A
Test: many clients (3A) ...
  ... Passed --  15.6  5  8180 1161
--- PASS: TestConcurrent3A (15.62s)
=== RUN   TestUnreliable3A
Test: unreliable net, many clients (3A) ...
  ... Passed --  16.4  5  4178  885
--- PASS: TestUnreliable3A (16.42s)
=== RUN   TestUnreliableOneKey3A
Test: concurrent append to same key, unreliable (3A) ...
  ... Passed --   2.1  3   294   52
--- PASS: TestUnreliableOneKey3A (2.08s)
=== RUN   TestOnePartition3A
Test: progress in majority (3A) ...
  ... Passed --   0.9  5    78    2
Test: no progress in minority (3A) ...
  ... Passed --   1.1  5    81    3
Test: completion after heal (3A) ...
  ... Passed --   2.0  5    63    3
--- PASS: TestOnePartition3A (4.72s)
=== RUN   TestManyPartitionsOneClient3A
Test: partitions, one client (3A) ...
  ... Passed --  22.9  5  4303  165
--- PASS: TestManyPartitionsOneClient3A (22.87s)
=== RUN   TestManyPartitionsManyClients3A
Test: partitions, many clients (3A) ...
  ... Passed --  24.6  5 22293  500
--- PASS: TestManyPartitionsManyClients3A (24.56s)
=== RUN   TestPersistOneClient3A
Test: restarts, one client (3A) ...
  ... Passed --  20.3  5 10804  530
--- PASS: TestPersistOneClient3A (20.33s)
=== RUN   TestPersistConcurrent3A
Test: restarts, many clients (3A) ...
  ... Passed --  22.2  5 40420 1135
--- PASS: TestPersistConcurrent3A (22.24s)
=== RUN   TestPersistConcurrentUnreliable3A
Test: unreliable net, restarts, many clients (3A) ...
  ... Passed --  29.3  5  7795  834
--- PASS: TestPersistConcurrentUnreliable3A (29.34s)
=== RUN   TestPersistPartition3A
Test: restarts, partitions, many clients (3A) ...
  ... Passed --  28.9  5 29930  643
--- PASS: TestPersistPartition3A (28.93s)
=== RUN   TestPersistPartitionUnreliable3A
Test: unreliable net, restarts, partitions, many clients (3A) ...
  ... Passed --  29.0  5  3932  320
--- PASS: TestPersistPartitionUnreliable3A (28.97s)
=== RUN   TestPersistPartitionUnreliableLinearizable3A
Test: unreliable net, restarts, partitions, random keys, many clients (3A) ...
  ... Passed --  35.4  7 10395  477
--- PASS: TestPersistPartitionUnreliableLinearizable3A (35.45s)
PASS
ok  	6.824/kvraft	280.547s

```