### PR TITLE
Lab 3B: Key/value service with snapshots

### DIFF
--- a/src/kvraft/common.go
+++ b/src/kvraft/common.go
@@ -46,9 +46,9 @@ type GetReply struct {
 
 type ClientOpRecord struct {
 	RequestID int64
-	reply     reply
+	Reply     reply
 }
 type reply struct {
-	value string
-	err   Err
+	Value string
+	Err   Err
 }

--- a/src/kvraft/state_machine.go
+++ b/src/kvraft/state_machine.go
@@ -43,3 +43,12 @@ func (s *InMemoryStateMachine) EncodeSnapshot(encoder *labgob.LabEncoder) error 
 	}
 	return nil
 }
+
+func (s *InMemoryStateMachine) DecodeSnapshot(decoder *labgob.LabDecoder) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := decoder.Decode(&s.data); err != nil {
+		return err
+	}
+	return nil
+}

--- a/src/kvraft/state_machine.go
+++ b/src/kvraft/state_machine.go
@@ -1,6 +1,10 @@
 package kvraft
 
-import "sync"
+import (
+	"sync"
+
+	"6.824/labgob"
+)
 
 type InMemoryStateMachine struct {
 	mu   sync.RWMutex
@@ -29,4 +33,13 @@ func (s *InMemoryStateMachine) Append(key string, value string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.data[key] += value
+}
+
+func (s *InMemoryStateMachine) EncodeSnapshot(encoder *labgob.LabEncoder) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if err := encoder.Encode(s.data); err != nil {
+		return err
+	}
+	return nil
 }

--- a/src/raft/raft.go
+++ b/src/raft/raft.go
@@ -955,7 +955,11 @@ func (rf *Raft) InstallSnapshot(args *InstallSnapshotArgs, reply *InstallSnapsho
 			SnapshotIndex: args.LastIncludedIndex,
 		}
 	}()
+}
 
+// RaftStateSize returns the size of the persisted state (3B)
+func (rf *Raft) RaftStateSize() int {
+	return rf.persister.RaftStateSize()
 }
 
 // the service or tester wants to create a Raft server. the ports

--- a/src/test.sh
+++ b/src/test.sh
@@ -26,3 +26,8 @@ for i in $(seq 1 $TIMES); do
   echo "Running test 3A-$i"
   VERBOSE=1 go test ./kvraft/... -race -run=3A -count=1
 done
+
+for i in $(seq 1 $TIMES); do
+  echo "Running test 3B-$i"
+  VERBOSE=1 go test ./kvraft/... -race -run="(TestSnapshotRPC3B|TestSnapshotSize3B)" -count=1
+done

--- a/src/test.sh
+++ b/src/test.sh
@@ -29,5 +29,5 @@ done
 
 for i in $(seq 1 $TIMES); do
   echo "Running test 3B-$i"
-  VERBOSE=1 go test ./kvraft/... -race -run="(TestSnapshotRPC3B|TestSnapshotSize3B)" -count=1
+  VERBOSE=1 go test ./kvraft/... -race -run="(TestSnapshotRPC3B|TestSnapshotSize3B|TestSpeed3B)" -count=1
 done


### PR DESCRIPTION
# [Key/value service with snapshots](http://nil.csail.mit.edu/6.824/2021/labs/lab-kvraft.html)

## Overview
- encode/decode snapshot
- kv server check if need snapshot
- kv server call `CondInstallSnapshot` when needed
- kv server restore snapshot
- recover snapshot on kv server start
- fix bug: https://github.com/hhow09/mit-6.824/issues/10
- fix underlying raft bugs

## Test Result
```
=== RUN   TestSnapshotRPC3B
Test: InstallSnapshot RPC (3B) ...
  ... Passed --   7.2  3  4053   63
--- PASS: TestSnapshotRPC3B (7.19s)
=== RUN   TestSnapshotSize3B
Test: snapshot size is reasonable (3B) ...
  ... Passed --   1.3  3  5227  800
--- PASS: TestSnapshotSize3B (1.31s)
=== RUN   TestSpeed3B
Test: ops complete fast enough (3B) ...
  ... Passed --   1.9  3  6596    0
--- PASS: TestSpeed3B (1.89s)
=== RUN   TestSnapshotRecover3B
Test: restarts, snapshots, one client (3B) ...
  ... Passed --  23.5  5 14896  521
--- PASS: TestSnapshotRecover3B (23.49s)
=== RUN   TestSnapshotRecoverManyClients3B
Test: restarts, snapshots, many clients (3B) ...
  ... Passed --  21.1  5 87107 18083
--- PASS: TestSnapshotRecoverManyClients3B (21.11s)
=== RUN   TestSnapshotUnreliable3B
Test: unreliable net, snapshots, many clients (3B) ...
  ... Passed --  16.3  5  5400 1115
--- PASS: TestSnapshotUnreliable3B (16.27s)
=== RUN   TestSnapshotUnreliableRecover3B
Test: unreliable net, restarts, snapshots, many clients (3B) ...
  ... Passed --  22.0  5  6482 1130
--- PASS: TestSnapshotUnreliableRecover3B (21.97s)
=== RUN   TestSnapshotUnreliableRecoverConcurrentPartition3B
Test: unreliable net, restarts, partitions, snapshots, many clients (3B) ...
  ... Passed --  29.4  5  3292  191
--- PASS: TestSnapshotUnreliableRecoverConcurrentPartition3B (29.39s)
=== RUN   TestSnapshotUnreliableRecoverConcurrentPartitionLinearizable3B
Test: unreliable net, restarts, partitions, snapshots, random keys, many clients (3B) ...
  ... Passed --  33.9  7 12716 1308
--- PASS: TestSnapshotUnreliableRecoverConcurrentPartitionLinearizable3B (33.87s)
PASS
ok  	6.824/kvraft	157.754s
```